### PR TITLE
Add depsdev as example application

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Example applications written in Go:
 - [`examples/package_lock_licenses`](./examples/go/package_lock_licenses) reads
   dependencies from an npm package-lock.json file and fetches their licenses
   from the deps.dev gRPC API.
+
+## Third party tools and integrations
+
+Note that these are community built tools and unsupported by the core deps.dev maintainers.
+
 - [`edoardottt/depsdev`](https://github.com/edoardottt/depsdev) CLI client (and Golang module) for deps.dev API.
 
 ## Contact us

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the gRPC API, along with example applications for both APIs.
 The HTTP API can be accessed using any HTTP client. To quickly get started, you
 can use the `curl` command-line tool. Example:
 
-```
+```console
 curl 'https://api.deps.dev/v3alpha/systems/npm/packages/%40colors%2Fcolors'
 ```
 
@@ -32,7 +32,7 @@ To quickly get started exploring the API, you can use the
 [`grpcurl`](https://github.com/fullstorydev/grpcurl) command-line tool.
 Example:
 
-```
+```console
 grpcurl \
   -d '{"package_key":{"system":"NPM","name":"@colors/colors"}}' \
   api.deps.dev:443 \
@@ -41,21 +41,22 @@ grpcurl \
 
 ## Example applications
 
-Example applications written in Go can be found in the `examples` directory:
+Example applications written in Go:
 
-- [`artifact_query`](./examples/go/artifact_query) shows how to query the
+- [`examples/artifact_query`](./examples/go/artifact_query) shows how to query the
   deps.dev HTTP API by file content hash.
-- [`dependencies_dot`](./examples/go/dependencies_dot) fetches a resolved
+- [`examples/dependencies_dot`](./examples/go/dependencies_dot) fetches a resolved
   dependency graph from the deps.dev HTTP API and renders it in the DOT
   language used by Graphviz.
-- [`package_lock_licenses`](./examples/go/package_lock_licenses) reads
+- [`examples/package_lock_licenses`](./examples/go/package_lock_licenses) reads
   dependencies from an npm package-lock.json file and fetches their licenses
   from the deps.dev gRPC API.
+- [`edoardottt/depsdev`](https://github.com/edoardottt/depsdev) CLI client (and Golang module) for deps.dev API.
 
 ## Contact us
 
 If you have questions about the API, or want to report a problem, please create
-an issue or contact us at open-source-insights@google.com.
+an issue or contact us at <open-source-insights@google.com>.
 
 ## Terms
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ grpcurl \
 
 ## Example applications
 
-Example applications written in Go:
+Example applications written in Go can be found in the `examples` directory:
 
-- [`examples/artifact_query`](./examples/go/artifact_query) shows how to query the
+- [`artifact_query`](./examples/go/artifact_query) shows how to query the
   deps.dev HTTP API by file content hash.
-- [`examples/dependencies_dot`](./examples/go/dependencies_dot) fetches a resolved
+- [`dependencies_dot`](./examples/go/dependencies_dot) fetches a resolved
   dependency graph from the deps.dev HTTP API and renders it in the DOT
   language used by Graphviz.
-- [`examples/package_lock_licenses`](./examples/go/package_lock_licenses) reads
+- [`package_lock_licenses`](./examples/go/package_lock_licenses) reads
   dependencies from an npm package-lock.json file and fetches their licenses
   from the deps.dev gRPC API.
 
@@ -61,7 +61,7 @@ Note that these are community built tools and unsupported by the core deps.dev m
 ## Contact us
 
 If you have questions about the API, or want to report a problem, please create
-an issue or contact us at <open-source-insights@google.com>.
+an issue or contact us at open-source-insights@google.com.
 
 ## Terms
 


### PR DESCRIPTION
AFAIK [depsdev](https://github.com/edoardottt/depsdev) is the only CLI client available for deps.dev API.  
This PR adds that tool as example app in the README file.