### PR TITLE
ci: update `go.yml` to build examples

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,10 +12,6 @@ jobs:
     
     strategy:
       matrix:
-        util:
-          - maven
-          - resolve
-          - semver
         examples:
           - artifact_query
           - dependencies_dot
@@ -37,8 +33,3 @@ jobs:
       working-directory: examples/go/${{ matrix.examples }}
       run: go test ./...
       
-    - name: Run util tests
-      working-directory: util/${{ matrix.util }}
-      run: go test ./...
-
-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,21 @@ on:
 jobs:
   go:
     runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        util:
+          - maven
+          - resolve
+          - semver
+        examples:
+          - artifact_query
+          - dependencies_dot
+          - maven_parse_resolve
+          - package_lock_licenses
+          - package_lock_licenses_batch
+          - resolve
+  
     steps:
     - name: Check out code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -18,14 +33,12 @@ jobs:
       with:
         go-version: stable
 
-    - name: Run tests in maven
-      working-directory: ./util/maven
+    - name: Build examples
+      working-directory: examples/go/${{ matrix.examples }}
+      run: go test ./...
+      
+    - name: Run util tests
+      working-directory: util/${{ matrix.util }}
       run: go test ./...
 
-    - name: Run tests in resolve
-      working-directory: ./util/resolve
-      run: go test ./...
 
-    - name: Run tests in semver
-      working-directory: ./util/semver
-      run: go test ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,18 +8,7 @@ on:
 
 jobs:
   go:
-    runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        examples:
-          - artifact_query
-          - dependencies_dot
-          - maven_parse_resolve
-          - package_lock_licenses
-          - package_lock_licenses_batch
-          - resolve
-  
+    runs-on: ubuntu-latest  
     steps:
     - name: Check out code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -30,6 +19,9 @@ jobs:
         go-version: stable
 
     - name: Build examples
-      working-directory: examples/go/${{ matrix.examples }}
-      run: go test ./...
-      
+      working-directory: examples/go/
+      run: |
+        for dir in $(ls); do
+          cd "$dir"
+          go build
+        done

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,4 +24,14 @@ jobs:
         for dir in $(ls -d */); do
           cd "$dir"
           go build
+          cd ..
+        done
+
+    - name: Run util tests
+      working-directory: util/
+      run: |
+        for dir in $(ls -d */); do
+          cd "$dir"
+          go test ./...
+          cd ..
         done

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,18 +20,8 @@ jobs:
 
     - name: Build examples
       working-directory: examples/go/
-      run: |
-        for dir in $(ls -d */); do
-          cd "$dir"
-          go build
-          cd ..
-        done
+      run: find . -name 'go.mod' -execdir go build \;
 
     - name: Run util tests
       working-directory: util/
-      run: |
-        for dir in $(ls -d */); do
-          cd "$dir"
-          go test ./...
-          cd ..
-        done
+      run: find . -name 'go.mod' -execdir go test ./... \;

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build examples
       working-directory: examples/go/
       run: |
-        for dir in $(ls); do
+        for dir in $(ls -d */); do
           cd "$dir"
           go build
         done

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   go:
-    runs-on: ubuntu-latest  
+    runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/examples/go/maven_parse_resolve/go.mod
+++ b/examples/go/maven_parse_resolve/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	deps.dev/api/v3 v3.0.0-20240311054650-e1e6a3d70fb7
-	deps.dev/util/maven v0.0.0-20240508074152-8a0b6d3a5b11
+	deps.dev/util/maven v0.0.0-20241203055422-1ee2cd4be494
 	deps.dev/util/resolve v0.0.0-20240611045547-af20eef0f1eb
 	google.golang.org/grpc v1.56.3
 )

--- a/examples/go/maven_parse_resolve/go.sum
+++ b/examples/go/maven_parse_resolve/go.sum
@@ -1,7 +1,7 @@
 deps.dev/api/v3 v3.0.0-20240311054650-e1e6a3d70fb7 h1:dleK4xoNCfxlfknQNPR1DmSdVErIAWlEzxtTImCqWXI=
 deps.dev/api/v3 v3.0.0-20240311054650-e1e6a3d70fb7/go.mod h1:k3RHZwAw7ijqoXmVDvcO7ikeTwTC4jtmhCDathV+IKE=
-deps.dev/util/maven v0.0.0-20240508074152-8a0b6d3a5b11 h1:Pj5eDqVZUx/CdWEAef6sb/xCOI/wwg7G+saoYMHGOW8=
-deps.dev/util/maven v0.0.0-20240508074152-8a0b6d3a5b11/go.mod h1:SBW3EribdkZYk6zxi5oVn/ZECvi4ixb7EGgEWfSimNk=
+deps.dev/util/maven v0.0.0-20241203055422-1ee2cd4be494 h1:owERvoPo5Ma5nMlBFXRNji18xF0DpvzAQd+TRv1CVBw=
+deps.dev/util/maven v0.0.0-20241203055422-1ee2cd4be494/go.mod h1:SBW3EribdkZYk6zxi5oVn/ZECvi4ixb7EGgEWfSimNk=
 deps.dev/util/resolve v0.0.0-20240611045547-af20eef0f1eb h1:BE7E7Ekn8OibNRzYeTLM7vsRplskWxjj9vNumfio6Vw=
 deps.dev/util/resolve v0.0.0-20240611045547-af20eef0f1eb/go.mod h1:XXi6yRYqhtxw5DvGX/mbG6fHSLn8OgoPowNd8EAxDgk=
 deps.dev/util/semver v0.0.0-20240109040450-1e316b822bc4 h1:RDmJe2F67jB7ovkbd28Pdpw3vEYUi2tWV5RlOHlxByk=

--- a/examples/go/resolve/go.mod
+++ b/examples/go/resolve/go.mod
@@ -14,7 +14,7 @@ require (
 )
 
 require (
-	deps.dev/util/maven v0.0.0-20240322043601-ff53416fec6a // indirect
+	deps.dev/util/maven v0.0.0-20241203055422-1ee2cd4be494 // indirect
 	deps.dev/util/semver v0.0.0-20240109040450-1e316b822bc4 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	golang.org/x/net v0.24.0 // indirect

--- a/examples/go/resolve/go.sum
+++ b/examples/go/resolve/go.sum
@@ -1,7 +1,7 @@
 deps.dev/api/v3 v3.0.0-20240311054650-e1e6a3d70fb7 h1:dleK4xoNCfxlfknQNPR1DmSdVErIAWlEzxtTImCqWXI=
 deps.dev/api/v3 v3.0.0-20240311054650-e1e6a3d70fb7/go.mod h1:k3RHZwAw7ijqoXmVDvcO7ikeTwTC4jtmhCDathV+IKE=
-deps.dev/util/maven v0.0.0-20240322043601-ff53416fec6a h1:4WKIvv/Ogb2QKl1pTby5VHuiwZy6UbHj1R21cGqzLUc=
-deps.dev/util/maven v0.0.0-20240322043601-ff53416fec6a/go.mod h1:SBW3EribdkZYk6zxi5oVn/ZECvi4ixb7EGgEWfSimNk=
+deps.dev/util/maven v0.0.0-20241203055422-1ee2cd4be494 h1:owERvoPo5Ma5nMlBFXRNji18xF0DpvzAQd+TRv1CVBw=
+deps.dev/util/maven v0.0.0-20241203055422-1ee2cd4be494/go.mod h1:SBW3EribdkZYk6zxi5oVn/ZECvi4ixb7EGgEWfSimNk=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=


### PR DESCRIPTION
This PR updates `go.yml` to make sure examples can be built successfully.
To address the build failures of two examples, this PR also updates `go.mod` files.
In addition, this PR lists the directories for building and testing so we don't need to manually list all directories.