### PR TITLE
docs: update README.md to include all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,18 @@ Example applications written in Go can be found in the `examples` directory:
 - [`dependencies_dot`](examples/go/dependencies_dot) fetches a resolved
   dependency graph from the deps.dev HTTP API and renders it in the DOT
   language used by Graphviz.
+- [`maven_parse_resolve`](examples/go/maven_parse_resolve) parses and
+  processes a Maven pom.xml and then calls the resolver to generate the
+  dependency graph.
 - [`package_lock_licenses`](examples/go/package_lock_licenses) and
   [`package_lock_licenses_batch`](examples/go/package_lock_licenses_batch)
   read dependencies from an npm package-lock.json file and fetch their licenses
   from deps.dev, using concurrent requests to the gRPC API or batch requests to
   the HTTP API, respectively.
+- [`resolve`](examples/go/resolve) performs dependency resolution for a single
+  version of a published npm package, and then compares the resulting graph with
+  the result from [`GetDependencies`](https://docs.deps.dev/api/v3alpha/#getdependencies)
+  endpoint.
 
 ## Third party tools and integrations
 


### PR DESCRIPTION
There were two Go examples missing in README.md.