### PR TITLE
chore: run `gofmt` as part of workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,9 +17,15 @@ jobs:
       uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: stable
-
-    - name: Gofmt
-      run: gofmt -l .
+      
+    - name: Check formatting
+      run: |
+        gofmt -w -s .
+        if [[ -n $(git diff --exit-code) ]]; then
+          echo "Go files were not formatted correctly:"
+          git diff
+          exit 1
+        fi
 
     - name: Build examples
       working-directory: examples/go/

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         go-version: stable
 
+    - name: Gofmt
+      run: gofmt -l .
+
     - name: Build examples
       working-directory: examples/go/
       run: find . -name 'go.mod' -execdir go build \;

--- a/examples/go/package_lock_licenses/main.go
+++ b/examples/go/package_lock_licenses/main.go
@@ -105,7 +105,7 @@ func main() {
 
 	// Traverse the dependency tree and find its set of unique package versions,
 	// including the root.
-	versions := map[Version]*VersionResponse{Version{pl.Name, pl.Version}: new(VersionResponse)}
+	versions := map[Version]*VersionResponse{{pl.Name, pl.Version}: new(VersionResponse)}
 	toVisit := []NPMDependency{{Version: pl.Version, Dependencies: pl.Dependencies}}
 	for len(toVisit) > 0 {
 		it := toVisit[0]

--- a/examples/go/package_lock_licenses_batch/main.go
+++ b/examples/go/package_lock_licenses_batch/main.go
@@ -137,7 +137,7 @@ func main() {
 
 	// Traverse the dependency tree and find its set of unique package versions,
 	// including the root.
-	versions := map[Version]*Result{Version{pl.Name, pl.Version}: new(Result)}
+	versions := map[Version]*Result{{pl.Name, pl.Version}: new(Result)}
 	toVisit := []NPMDependency{{Version: pl.Version, Dependencies: pl.Dependencies}}
 	for len(toVisit) > 0 {
 		it := toVisit[0]

--- a/util/semver/constraint.go
+++ b/util/semver/constraint.go
@@ -94,13 +94,17 @@ func (sys System) ParseConstraint(str string) (retC *Constraint, retErr error) {
 // in the packaging system. The syntax is system-independent. Trimmed of leading
 // and trailing spaces, the syntax is a list of comma-separated spans inside a
 // braces:
+//
 //	{span,span,...}
+//
 // There are no extraneous spaces. The string "{}" is the empty set and matches
 // nothing.
 // Spans are formatted according to their rank:
+//
 //	An empty span: <empty>
 //	A single version: 1.2.3-alpha
 //	A span between two versions: [1.2.3:2.3.4]
+//
 // In the last case, a bracket will be ( or ) if the span is open on the
 // corresponding side. On the right-hand side of a span, a number (major, minor,
 // patch) may be replaced with ∞ to represent a value greater than all numeric
@@ -178,11 +182,13 @@ func (p *constraintParser) constraint() (*Constraint, error) {
 }
 
 /*
-	orList = span // See value method below.
-		| andList
-		| orList '||' andList // NPM, Default only.
-		| orList ',' andList // Maven and NuGet only.
-	span = VERSION ' ' '-' ' ' VERSION // NPM, Default only. Spaces required.
+orList = span // See value method below.
+
+	| andList
+	| orList '||' andList // NPM, Default only.
+	| orList ',' andList // Maven and NuGet only.
+
+span = VERSION ' ' '-' ' ' VERSION // NPM, Default only. Spaces required.
 */
 func (p *constraintParser) orList() Set {
 	sys := p.Constraint.sys
@@ -230,7 +236,6 @@ func (p *constraintParser) orList() Set {
 	andList = value
 		| andList value
 		| andList ',' value // If comma is supported for AND.
-
 
 If the value is a span, it must be the only item in the list.
 See the value method below.
@@ -424,6 +429,7 @@ func (p *constraintParser) value() (spans []span, hyphenated, valid bool) {
 
 /*
 setRange parses a version range in Maven/NuGet syntax for constraints.
+
 	range = VERSION
 		| '[' VERSION ']'
 		| lbra opVersion ',' opVersion rbra

--- a/util/semver/set.go
+++ b/util/semver/set.go
@@ -231,7 +231,7 @@ func (s *Set) Intersect(t Set) error {
 	}
 	if len(out) == 0 {
 		// An empty list means everything, so we need an explicitly empty span.
-		out = []span{span{rank: empty}}
+		out = []span{{rank: empty}}
 	}
 	var err error
 	s.span, err = canon(out)

--- a/util/semver/token.go
+++ b/util/semver/token.go
@@ -86,7 +86,7 @@ var byteType = [...]uint8{
 }
 
 var operators = []map[string]tokType{
-	DefaultSystem: map[string]tokType{
+	DefaultSystem: {
 		"=":  tokEqual,
 		">":  tokGreater,
 		">=": tokGreaterEqual,
@@ -100,7 +100,7 @@ var operators = []map[string]tokType{
 		"-":  tokHyphen,
 	},
 
-	Cargo: map[string]tokType{
+	Cargo: {
 		"=":  tokEqual,
 		">":  tokGreater,
 		">=": tokGreaterEqual,
@@ -111,7 +111,7 @@ var operators = []map[string]tokType{
 		",":  tokComma,
 	},
 
-	NPM: map[string]tokType{
+	NPM: {
 		"=":  tokEqual,
 		">":  tokGreater,
 		">=": tokGreaterEqual,
@@ -124,17 +124,17 @@ var operators = []map[string]tokType{
 		"-":  tokHyphen,
 	},
 
-	Go: map[string]tokType{},
+	Go: {},
 
-	Maven: map[string]tokType{
+	Maven: {
 		",": tokComma,
 	},
 
-	NuGet: map[string]tokType{
+	NuGet: {
 		",": tokComma,
 	},
 
-	PyPI: map[string]tokType{
+	PyPI: {
 		"==": tokEqual,
 		">":  tokGreater,
 		">=": tokGreaterEqual,
@@ -145,7 +145,7 @@ var operators = []map[string]tokType{
 		",":  tokComma,
 	},
 
-	RubyGems: map[string]tokType{
+	RubyGems: {
 		"=":  tokEqual,
 		">":  tokGreater,
 		">=": tokGreaterEqual,


### PR DESCRIPTION
This PR adds `gofmt` to the Go workflow so that we will be alerted any diffs.