### PR TITLE
ci: also return non-zero exit status

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,4 @@ jobs:
 
     - name: Run util tests
       working-directory: util/
-      env:
-          ACTIONS_STEP_DEBUG: true
-      run: find . -name 'go.mod' -execdir go test ./... \;
+      run: for DIR in $(find . -name 'go.mod'); do cd $(dirname $DIR); go test ./... || exit 1; cd -; done

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,4 +24,4 @@ jobs:
 
     - name: Run util tests
       working-directory: util/
-      run: find . -name 'go.mod' -execdir go test ./... \;
+      run: find . -name 'go.mod' -execdir go test ./... \+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,8 +20,10 @@ jobs:
 
     - name: Build examples
       working-directory: examples/go/
-      run: find . -name 'go.mod' -execdir go build \; && false
+      run: find . -name 'go.mod' -execdir go build \;
 
     - name: Run util tests
       working-directory: util/
-      run: find . -name 'go.mod' -execdir go test ./... \; && false
+      env:
+          ACTIONS_STEP_DEBUG: true
+      run: find . -name 'go.mod' -execdir go test ./... \;

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,4 +24,4 @@ jobs:
 
     - name: Run util tests
       working-directory: util/
-      run: find . -name 'go.mod' -execdir go test ./... \+
+      run: find . -name 'go.mod' -execdir go test ./... +

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Build examples
       working-directory: examples/go/
-      run: find . -name 'go.mod' -execdir go build \;
+      run: for DIR in $(find . -name 'go.mod'); do cd $(dirname $DIR); go build || exit 1; cd -; done
 
     - name: Run util tests
       working-directory: util/

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,8 +20,8 @@ jobs:
 
     - name: Build examples
       working-directory: examples/go/
-      run: find . -name 'go.mod' -execdir go build \;
+      run: find . -name 'go.mod' -execdir go build \; && false
 
     - name: Run util tests
       working-directory: util/
-      run: find . -name 'go.mod' -execdir go test ./... +
+      run: find . -name 'go.mod' -execdir go test ./... \; && false

--- a/util/maven/string_test.go
+++ b/util/maven/string_test.go
@@ -28,7 +28,7 @@ func TestString(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to unmarshal: %v", err)
 	}
-	if got.Str != "test" {
+	if got.Str != "abc" {
 		t.Fatalf("unmarshal string want: %s, got: %s", "test", got.Str)
 	}
 }

--- a/util/maven/string_test.go
+++ b/util/maven/string_test.go
@@ -28,7 +28,7 @@ func TestString(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to unmarshal: %v", err)
 	}
-	if got.Str != "abc" {
+	if got.Str != "test" {
 		t.Fatalf("unmarshal string want: %s, got: %s", "test", got.Str)
 	}
 }


### PR DESCRIPTION
`find -execdir` does return non-exit code which hides the build/test failures.

To be able to return non-zero exit code, this PR runs `go build` and `go test` in the loop of directories listed by `find`.