### PR TITLE
chore: specify Go versions with `1.N.P` syntax

### DIFF
--- a/api/v3/go.mod
+++ b/api/v3/go.mod
@@ -1,6 +1,6 @@
 module deps.dev/api/v3
 
-go 1.23
+go 1.23.4
 
 require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1

--- a/api/v3alpha/go.mod
+++ b/api/v3alpha/go.mod
@@ -1,6 +1,6 @@
 module deps.dev/api/v3alpha
 
-go 1.23
+go 1.23.4
 
 require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1

--- a/examples/go/artifact_query/go.mod
+++ b/examples/go/artifact_query/go.mod
@@ -1,3 +1,3 @@
 module github.com/google/deps.dev/examples/go/artifact_query
 
-go 1.23
+go 1.23.4

--- a/examples/go/dependencies_dot/go.mod
+++ b/examples/go/dependencies_dot/go.mod
@@ -1,3 +1,3 @@
 module github.com/google/deps.dev/examples/go/dependencies_dot
 
-go 1.23
+go 1.23.4

--- a/examples/go/maven_parse_resolve/go.mod
+++ b/examples/go/maven_parse_resolve/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/deps.dev/examples/go/maven_parse_resolve
 
-go 1.23
+go 1.23.4
 
 require (
 	deps.dev/api/v3 v3.0.0-20240311054650-e1e6a3d70fb7

--- a/examples/go/package_lock_licenses/go.mod
+++ b/examples/go/package_lock_licenses/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/deps.dev/examples/go/package_lock_licenses
 
-go 1.23
+go 1.23.4
 
 require (
 	deps.dev/api/v3alpha v0.0.0-20240701033337-efe6530670b9

--- a/examples/go/package_lock_licenses_batch/go.mod
+++ b/examples/go/package_lock_licenses_batch/go.mod
@@ -1,3 +1,3 @@
 module github.com/google/deps.dev/examples/go/package_lock_licenses_batch
 
-go 1.23
+go 1.23.4

--- a/examples/go/resolve/go.mod
+++ b/examples/go/resolve/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/deps.dev/examples/go/resolve
 
-go 1.23
+go 1.23.4
 
 replace (
 	deps.dev/util/maven => ../../../util/maven

--- a/util/maven/go.mod
+++ b/util/maven/go.mod
@@ -1,6 +1,6 @@
 module deps.dev/util/maven
 
-go 1.23
+go 1.23.4
 
 replace deps.dev/util/semver => ../semver
 

--- a/util/resolve/go.mod
+++ b/util/resolve/go.mod
@@ -1,6 +1,6 @@
 module deps.dev/util/resolve
 
-go 1.23
+go 1.23.4
 
 replace (
 	deps.dev/util/maven => ../maven

--- a/util/semver/go.mod
+++ b/util/semver/go.mod
@@ -1,3 +1,3 @@
 module deps.dev/util/semver
 
-go 1.23
+go 1.23.4


### PR DESCRIPTION
[CodeQL](https://github.com/google/deps.dev/security/code-scanning/tools/CodeQL/status/configurations/automatic/e3590f4cd60ff2b42bab2e8d21b799791453973e5246c2fba04edd209105a6e0) warns about invalid Go toolchain version:
```
As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
```

This PR specifies the Go version in `go.mod` files following the syntax.