### PR TITLE
util/maven: remove unnecessary code

### DIFF
--- a/util/maven/string.go
+++ b/util/maven/string.go
@@ -120,9 +120,6 @@ func (fb *FalsyBool) interpolate(dictionary map[string]string) bool {
 }
 
 func (fb *FalsyBool) Boolean() bool {
-	if *fb == "" {
-		return false
-	}
 	return *fb == "true"
 }
 


### PR DESCRIPTION
`*fb == "true"` covers the case of `*fb` being empty and returns false.