### PR TITLE
util/resolve: adjust require of `deps.dev/util/pypi`

### DIFF
--- a/util/resolve/go.mod
+++ b/util/resolve/go.mod
@@ -11,13 +11,13 @@ replace (
 require (
 	deps.dev/api/v3 v3.0.0-20240311054650-e1e6a3d70fb7
 	deps.dev/util/maven v0.0.0-20240322043601-ff53416fec6a
+	deps.dev/util/pypi v0.0.0-00010101000000-000000000000
 	deps.dev/util/semver v0.0.0-20241230231135-52b7655a522f
 	github.com/google/go-cmp v0.7.0
 	google.golang.org/grpc v1.70.0
 )
 
 require (
-	deps.dev/util/pypi v0.0.0-00010101000000-000000000000 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/util/resolve/go.mod
+++ b/util/resolve/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	deps.dev/api/v3 v3.0.0-20240311054650-e1e6a3d70fb7
 	deps.dev/util/maven v0.0.0-20240322043601-ff53416fec6a
-	deps.dev/util/pypi v0.0.0-00010101000000-000000000000
+	deps.dev/util/pypi v0.0.0-20250307021655-d811e36f9cad
 	deps.dev/util/semver v0.0.0-20241230231135-52b7655a522f
 	github.com/google/go-cmp v0.7.0
 	google.golang.org/grpc v1.70.0


### PR DESCRIPTION
Currently I'm getting an error over at `osv-scalibr` when trying to run `go list` which is used by my IDE:

```
/home/jones/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/bin/go list -json -m -u -mod=readonly all #gosetup
go: deps.dev/util/pypi@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```

From my research, it seems that this revision is used by Go in some situations, such as when you have a `replace` directive without a corresponding `require` directive, though I'm still not actually sure if that is invalid.

I am suspect though that there are direct requires for the other `replace`'d utils which have more expected revision SHAs - ~I suspect this might have been the result of the new package being introduced in the same PR as it was being required, so it literally didn't exist upstream at the time?~

I've attempted to fix this by running `go get deps.dev/util/pypi@latest`