### PR TITLE
.github: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,29 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directories: 
+    directories:
       - "/api/*"
       - "/examples/go/*"
       - "/util/*"
     schedule:
       interval: "weekly"
-
+    groups:
+      go:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Group minor and patch version updates for go and github-actions to reduce the number of pull requests.

Security and major version updates will continue to be handled in separate pull requests.