### PR TITLE
util/maven: Add InterpolateRepositories for Maven Project

### DIFF
--- a/util/maven/project.go
+++ b/util/maven/project.go
@@ -314,8 +314,8 @@ func (p *Project) InterpolateRepositories() error {
 		return err
 	}
 
-	for _, r := range p.Repositories {
-		r.interpolate(properties)
+	for i := range p.Repositories {
+		p.Repositories[i].interpolate(properties)
 	}
 
 	return nil


### PR DESCRIPTION
 This change adds `func InterpolateRepositories` to Maven project so that we can still resolve the properties in Maven repositories without interpolating everything.