### PR TITLE
semver: fix intersection of point and open range

### DIFF
--- a/util/semver/set_test.go
+++ b/util/semver/set_test.go
@@ -196,6 +196,12 @@ func TestIntersect(t *testing.T) {
 		{strs("[1.0.0:2.0.0]"), strs("[1.0.0:2.0.0)"), "{[1.0.0:2.0.0)}"},
 		{strs("<1.2.3"), strs("<=1.2.3"), "{[0.0.0-0:1.2.3)}"},
 		{strs("<=1.2.3"), strs("<1.2.3"), "{[0.0.0-0:1.2.3)}"},
+
+		// Bug regression: Intersecting [1.0.0, 1.0.0] with (1.0.0, inf) should be empty.
+		// We use <1.0.0 vs 1.0.0 to trigger [0, 1) vs [1, 1].
+		{strs("<1.0.0"), strs("1.0.0"), "{<empty>}"},
+		// We use >1.0.0 vs 1.0.0 to trigger (1, inf) vs [1, 1].
+		{strs(">1.0.0"), strs("1.0.0"), "{<empty>}"},
 	}
 	for _, test := range tests {
 		set1 := Set{DefaultSystem, spans(t, test.s1...)}

--- a/util/semver/span.go
+++ b/util/semver/span.go
@@ -135,6 +135,9 @@ func newSpan(min *Version, minOpen bool, max *Version, maxOpen bool) (span, erro
 	max.build = ""
 	switch {
 	case min.equal(max):
+		if minOpen || maxOpen {
+			return span{rank: empty}, nil
+		}
 		return span{
 			minOpen: minOpen,
 			maxOpen: maxOpen,


### PR DESCRIPTION
Fixes a bug where intersecting a point version like [1.0.0, 1.0.0] with an open range like (1.0.0, inf) incorrectly resulted in a valid span instead of empty. Added regression tests.