### PR TITLE
feat(util/maven): support parsing modules in project

### DIFF
--- a/util/maven/project.go
+++ b/util/maven/project.go
@@ -62,6 +62,7 @@ type Project struct {
 
 	Licenses               []License              `xml:"licenses>license,omitempty"`
 	Developers             []Developer            `xml:"developers>developer,omitempty"`
+	Modules                []String               `xml:"modules>module,omitempty"`
 	SCM                    SCM                    `xml:"scm,omitempty"`
 	IssueManagement        IssueManagement        `xml:"issueManagement,omitempty"`
 	DistributionManagement DistributionManagement `xml:"distributionManagement,omitempty"`
@@ -303,6 +304,14 @@ func (p *Project) Interpolate() error {
 		}
 	}
 	p.Repositories = repos
+
+	var modules []String
+	for _, m := range p.Modules {
+		if ok := m.interpolate(properties); ok {
+			modules = append(modules, m)
+		}
+	}
+	p.Modules = modules
 
 	return nil
 }

--- a/util/maven/project_test.go
+++ b/util/maven/project_test.go
@@ -210,6 +210,27 @@ func TestProject(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("unmarshal input:\n(- got, + want):\n%s", diff)
 	}
+
+	inputAggregator, err := os.ReadFile("testdata/aggregator-1.0.0.xml")
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	wantAggregator := Project{
+		ProjectKey: ProjectKey{
+			GroupID:    "com.example",
+			ArtifactID: "aggregator",
+			Version:    "1.0.0",
+		},
+		Packaging: "pom",
+		Modules:   []String{"module-1", "module-2"},
+	}
+	var gotAggregator Project
+	if err := xml.Unmarshal(inputAggregator, &gotAggregator); err != nil {
+		t.Fatalf("failed to unmarshal input: %v", err)
+	}
+	if diff := cmp.Diff(gotAggregator, wantAggregator); diff != "" {
+		t.Errorf("unmarshal aggregator input:\n(- got, + want):\n%s", diff)
+	}
 }
 
 func TestMergeParent(t *testing.T) {

--- a/util/maven/testdata/aggregator-1.0.0.xml
+++ b/util/maven/testdata/aggregator-1.0.0.xml
@@ -1,0 +1,10 @@
+<project>
+    <groupId>com.example</groupId>
+    <artifactId>aggregator</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>module-1</module>
+        <module>module-2</module>
+    </modules>
+</project>


### PR DESCRIPTION
This PR adds support to parse modules in `maven.Project`:
 - Add `Modules` field to `Project` struct to support parsing `<modules>` from POM files.
 - Add interpolation for `Modules` in `Interpolate` method to resolve property placeholders.
 - Add a new test file `aggregator-1.0.0.xml` and a corresponding test case in `TestProject` to verify modules parsing.
