### PR TITLE
fix(util/semver): reject empty constraint for Maven

### DIFF
--- a/util/semver/constraint.go
+++ b/util/semver/constraint.go
@@ -74,7 +74,7 @@ func (sys System) ParseConstraint(str string) (retC *Constraint, retErr error) {
 	// creating the empty set, which means the opposite.
 	lexStr := str
 	if lexStr == "" {
-		if sys == NuGet {
+		if sys == NuGet || sys == Maven {
 			return nil, fmt.Errorf("invalid empty constraint")
 		}
 		lexStr = ">=0.0.0"

--- a/util/semver/maven_test.go
+++ b/util/semver/maven_test.go
@@ -81,13 +81,13 @@ func TestMavenCanon(t *testing.T) {
 }
 
 var mavenConstraintErrorTests = []constraintErrorTest{
+	{"", "invalid empty constraint"},
 	{"[", "expected comma or closing bracket in `[`"},
 	{"()", "hard requirement must be closed on both ends in `()`"},
 	{")", "unexpected rbracket in `)`"},
 	{"(1.0)", "hard requirement must be closed on both ends in `(1.0)`"},
 	{"[1.0]]2.0]", "unexpected rbracket in `[1.0]]2.0]`"},
 	{"[1.0][2.0]", "unexpected lbracket in `[1.0][2.0]`"},
-	{"", "invalid empty constraint"},
 }
 
 func TestMavenConstraintError(t *testing.T) {

--- a/util/semver/maven_test.go
+++ b/util/semver/maven_test.go
@@ -87,6 +87,7 @@ var mavenConstraintErrorTests = []constraintErrorTest{
 	{"(1.0)", "hard requirement must be closed on both ends in `(1.0)`"},
 	{"[1.0]]2.0]", "unexpected rbracket in `[1.0]]2.0]`"},
 	{"[1.0][2.0]", "unexpected lbracket in `[1.0][2.0]`"},
+	{"", "invalid empty constraint"},
 }
 
 func TestMavenConstraintError(t *testing.T) {


### PR DESCRIPTION
This PR rejects empty version constraints for Maven in `ParseConstraint`. In Maven projects, omitting a version is invalid, so previously treating it as valid or falling back to unsupported syntax is incorrect.