### PR TITLE
fix(semver): restrict PEP 440 local version comparison to minimum length

### DIFF
--- a/util/semver/pep440.go
+++ b/util/semver/pep440.go
@@ -592,7 +592,7 @@ func pep44CompareLocal(pl, ql string) int {
 		n = qn
 	}
 	var pElem, qElem string
-	for i := 0; i < pn; i++ {
+	for i := 0; i < n; i++ {
 		pElem, pl = pep440LocalElem(pl)
 		qElem, ql = pep440LocalElem(ql)
 		if s := p440compareLocalElem(pElem, qElem); s != 0 {


### PR DESCRIPTION
This PR fixes a minor logic issue in the PEP 440 local version comparison function where the loop counter compared up to the length of the first version string (pn) rather than the minimum of both version strings (n). This could lead to calling pep440LocalElem on an empty string and unnecessary iterations. Using n avoids this and compares only up to the shared components length.