### PR TITLE
util/maven: do not add dependency management when version is empty

### DIFF
--- a/util/maven/dependency.go
+++ b/util/maven/dependency.go
@@ -118,7 +118,9 @@ func (p *Project) ProcessDependencies(getDependencyManagement func(String, Strin
 				continue
 			}
 			dk := dep.Key()
-			if _, ok := m[dk]; !ok {
+			if _, ok := m[dk]; !ok && dep.Version != "" {
+				// Only add dependency management when it is not in the map and
+				// the version is not empty.
 				m[dk] = dep
 				keys = append(keys, dk)
 			}


### PR DESCRIPTION
Maven POMs may contain `<dependencyManagement>` entries without a `version` field.

Previously, `ProcessDependencies` stored these versionless entries, preventing dependency management with the actual version constraint to be stored.

This PR updated `addDepManagement` in `util/maven/dependency.go` to explicitly require `dep.Version != ""` before adding an entry to the map.
