### PR TITLE
util/maven: update dependency version when existing one has empty version

### DIFF
--- a/util/maven/dependency.go
+++ b/util/maven/dependency.go
@@ -129,9 +129,13 @@ func (p *Project) ProcessDependencies(getDependencyManagement func(String, Strin
 	depKeys := make([]DependencyKey, 0, len(p.Dependencies))
 	for _, dep := range p.Dependencies {
 		dk := dep.Key()
-		if _, ok := deps[dk]; !ok {
+		if existing, ok := deps[dk]; !ok {
 			deps[dk] = dep
 			depKeys = append(depKeys, dk)
+		} else if existing.Version == "" && dep.Version != "" {
+			// Update the version when it is empty.
+			existing.Version = dep.Version
+			deps[dk] = existing
 		}
 	}
 	depManagement := make(map[DependencyKey]Dependency, len(p.DependencyManagement.Dependencies))

--- a/util/maven/dependency_test.go
+++ b/util/maven/dependency_test.go
@@ -46,6 +46,13 @@ func TestProcessDependencies(t *testing.T) {
 			GroupID:    "org.aaa",
 			ArtifactID: "dep",
 			Version:    "5.0.0",
+		}, {
+			GroupID:    "org.empty",
+			ArtifactID: "dep",
+		}, {
+			GroupID:    "org.empty",
+			ArtifactID: "dep",
+			Version:    "1.2.3",
 		}},
 		DependencyManagement: DependencyManagement{
 			Dependencies: []Dependency{{
@@ -133,6 +140,11 @@ func TestProcessDependencies(t *testing.T) {
 			GroupID:    "org.eee",
 			ArtifactID: "dep",
 			Version:    "5.0.0",
+			Type:       "jar",
+		}, {
+			GroupID:    "org.empty",
+			ArtifactID: "dep",
+			Version:    "1.2.3",
 			Type:       "jar",
 		}},
 		DependencyManagement: DependencyManagement{


### PR DESCRIPTION
In `Project.ProcessDependencies`, Maven dependencies are deduplicated into a key-based map. Previously, first-seen dependencies were kept and subsequent duplicates were ignored.

This PR updates the logic to handle cases where an initial dependency declaration has an empty version, but a subsequent duplicate explicitly specifies the version.