### PR TITLE
util/maven: support parsing and merging modules in build profiles

### DIFF
--- a/util/maven/profile.go
+++ b/util/maven/profile.go
@@ -27,6 +27,7 @@ type Profile struct {
 	ID                   String               `xml:"id,omitempty"`
 	Activation           Activation           `xml:"activation,omitempty"`
 	Properties           Properties           `xml:"properties,omitempty"`
+	Modules              []String             `xml:"modules>module,omitempty"`
 	DependencyManagement DependencyManagement `xml:"dependencyManagement,omitempty"`
 	Dependencies         []Dependency         `xml:"dependencies>dependency,omitempty"`
 	Repositories         []Repository         `xml:"repositories>repository,omitempty"`
@@ -201,6 +202,7 @@ func (p *Project) MergeProfiles(jdk string, os ActivationOS) (err error) {
 		p.DependencyManagement.merge(prof.DependencyManagement)
 		p.Dependencies = append(p.Dependencies, prof.Dependencies...)
 		p.Repositories = append(p.Repositories, prof.Repositories...)
+		p.Modules = append(p.Modules, prof.Modules...)
 	}
 	return
 }

--- a/util/maven/profile_test.go
+++ b/util/maven/profile_test.go
@@ -62,6 +62,10 @@ func TestProfile(t *testing.T) {
 			ArtifactID: "def",
 			Version:    "${def.version}",
 		}},
+		Modules: []String{
+			"module-a",
+			"module-b",
+		},
 	}, {
 		ID: "my-profile-2",
 		Activation: Activation{
@@ -362,6 +366,7 @@ func TestMergeProfiles(t *testing.T) {
 				{Name: "abc.version", Value: "1.0.0"},
 			},
 		},
+		Modules: []String{"default-module"},
 		Profiles: []Profile{{
 			// Not activated
 			Activation: Activation{
@@ -378,6 +383,7 @@ func TestMergeProfiles(t *testing.T) {
 					{Name: "abc.version", Value: "9.9.9"},
 				},
 			},
+			Modules: []String{"module-not-activated"},
 		}, {
 			// Activated
 			Activation: Activation{
@@ -395,6 +401,7 @@ func TestMergeProfiles(t *testing.T) {
 					{Name: "abc.version", Value: "2.0.0"},
 				},
 			},
+			Modules: []String{"module-activated-1", "module-activated-2"},
 		}, {
 			// Activated
 			Activation: Activation{
@@ -419,6 +426,7 @@ func TestMergeProfiles(t *testing.T) {
 					{Name: "abc.version", Value: "3.0.0"},
 				},
 			},
+			Modules: []String{"module-activated-3"},
 		}},
 	}
 	proj.MergeProfiles(JDKProfileActivation, OSProfileActivation)
@@ -447,6 +455,7 @@ func TestMergeProfiles(t *testing.T) {
 				{Name: "abc.version", Value: "3.0.0"},
 			},
 		},
+		Modules: []String{"default-module", "module-activated-1", "module-activated-2", "module-activated-3"},
 	}
 	proj.Profiles = nil
 	if diff := cmp.Diff(proj, want); diff != "" {

--- a/util/maven/testdata/profiles.xml
+++ b/util/maven/testdata/profiles.xml
@@ -51,6 +51,10 @@
                     <version>${def.version}</version>
                 </dependency>
             </dependencies>
+            <modules>
+                <module>module-a</module>
+                <module>module-b</module>
+            </modules>
         </profile>
         <profile>
             <id>my-profile-2</id>


### PR DESCRIPTION
This PR adds support for the `<modules>` tag inside Maven profiles:
- Added `Modules []String` to the `Profile` struct.
- Updated `MergeProfiles` to append active profiles' modules to the main project modules list.
- Added tests for parsing and merging behavior.