### PR TITLE
util/resolve: sort versions in APIClient.Versions

### DIFF
--- a/util/resolve/api.go
+++ b/util/resolve/api.go
@@ -144,6 +144,10 @@ func (a *APIClient) Versions(ctx context.Context, pk PackageKey) ([]Version, err
 			Version:     v.VersionKey.Version,
 		}, v, "")
 	}
+	// Sort the versions into the ascending order expected by the resolvers;
+	// the API may return them in a different order (e.g. lexicographic for
+	// PyPI).
+	SortVersions(vers)
 	return vers, nil
 }
 

--- a/util/resolve/api_test.go
+++ b/util/resolve/api_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
 
 	pb "deps.dev/api/v3"
 	"deps.dev/util/resolve/internal/deptest"
@@ -324,5 +325,60 @@ func TestPyPIRequirements(t *testing.T) {
 		if d := cmp.Diff(c.out, got); d != "" {
 			t.Errorf("pypiRequirements(%v):\n(- want, + got):\n%s", c.in, d)
 		}
+	}
+}
+
+// mockInsightsClient is a pb.InsightsClient that returns a fixed package
+// from GetPackage; the other methods are not implemented and are not
+// called by the tests.
+type mockInsightsClient struct {
+	pb.InsightsClient
+	pkg *pb.Package
+}
+
+func (m *mockInsightsClient) GetPackage(ctx context.Context, in *pb.GetPackageRequest, opts ...grpc.CallOption) (*pb.Package, error) {
+	return m.pkg, nil
+}
+
+func TestVersions(t *testing.T) {
+	ctx := context.Background()
+	pk := PackageKey{
+		System: PyPI,
+		Name:   "test",
+	}
+	vers := func(v string) *pb.Package_Version {
+		return &pb.Package_Version{
+			VersionKey: &pb.VersionKey{
+				System:  pb.System_PYPI,
+				Name:    "test",
+				Version: v,
+			},
+		}
+	}
+	// The versions in the lexicographic order returned by the deps.dev API
+	// for PyPI, where "9.1.0" comes after "84.0.0".
+	client := APIClient{
+		c: &mockInsightsClient{pkg: &pb.Package{
+			Versions: []*pb.Package_Version{
+				vers("0.9.0"),
+				vers("1.10.0"),
+				vers("1.9.0"),
+				vers("2.0.0"),
+				vers("84.0.0"),
+				vers("9.1.0"),
+			},
+		}},
+	}
+	got, err := client.Versions(ctx, pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotVersions []string
+	for _, v := range got {
+		gotVersions = append(gotVersions, v.Version)
+	}
+	wantVersions := []string{"0.9.0", "1.9.0", "1.10.0", "2.0.0", "9.1.0", "84.0.0"}
+	if d := cmp.Diff(wantVersions, gotVersions); d != "" {
+		t.Errorf("Versions(%v):\n(- want, + got):\n%s", pk, d)
 	}
 }

--- a/util/resolve/client.go
+++ b/util/resolve/client.go
@@ -46,7 +46,8 @@ type Client interface {
 	// Version finds a particular version, providing access to its
 	// attributes.
 	Version(context.Context, VersionKey) (Version, error)
-	// Versions returns all the known versions of a package.
+	// Versions returns all the known versions of a package, in a
+	// system-specific order, expected by the relevant resolver.
 	Versions(context.Context, PackageKey) ([]Version, error)
 	// Requirements returns the direct dependencies of the provided version.
 	Requirements(context.Context, VersionKey) ([]RequirementVersion, error)


### PR DESCRIPTION
Fixes #385.

Supersedes #386 (closed after a head-branch rename)

Continuing the review thread with @cuixq, who suggested sorting at the API client layer and documenting on `Client.Versions` that the versions should be sorted.

## Problem

`APIClient.Versions` returned versions in the order returned by the deps.dev API, which is not ascending (for PyPI, at least, it is lexicographic, where "9.1.0" comes after "84.0.0"). The PyPI resolver iterates the version list in descending order, relying on it being sorted ascending, so unpinned transitive requirements resolved to the lexicographic maximum (e.g. `setuptools 9.1.0` instead of `84.0.0`).

## Fix

Sort the versions in `APIClient.Versions`, the layer that converts the API response, and document the ordering contract on `Client.Versions`.

## Test

`TestVersions` feeds a lexicographically ordered PyPI version list to `APIClient.Versions` and asserts the ascending order, and verified the test fails without the fix.